### PR TITLE
Add issue_tracker link, remove bs4 import

### DIFF
--- a/custom_components/afvalinfo/location/trashapi.py
+++ b/custom_components/afvalinfo/location/trashapi.py
@@ -3,9 +3,7 @@ from ..const.const import (
     SENSOR_LOCATIONS_TO_URL,
     _LOGGER,
 )
-from datetime import datetime
-from datetime import timedelta
-from bs4 import BeautifulSoup
+from datetime import datetime, timedelta
 import urllib.request
 import urllib.error
 import requests

--- a/custom_components/afvalinfo/manifest.json
+++ b/custom_components/afvalinfo/manifest.json
@@ -3,12 +3,12 @@
   "name": "Afvalinfo",
   "version": "0.8.1",
   "documentation": "https://github.com/heyajohnny/afvalinfo",
+  "issue_tracker": "https://github.com/heyajohnny/afvalinfo/issues",
   "dependencies": [],
   "codeowners": [
     "@heyajohnny"
   ],
   "requirements": [
-    "beautifulsoup4==4.9.0",
     "Babel==2.8.0",
     "python-dateutil==2.8.1"
   ]


### PR DESCRIPTION
Ok, this started as "let's add an issue tracker link here":

![image](https://user-images.githubusercontent.com/33529490/115350475-717b7180-a1b5-11eb-9d40-643195955f50.png)

Then I noticed that `manifest.json` lists BS4 as requirement, but I couldn't remember it being used in the code. Upon review, this seems to be a correct memory hence why I removed it.



