### PR TITLE
Fix 2021.12.0 warnings

### DIFF
--- a/custom_components/afvalinfo/sensor.py
+++ b/custom_components/afvalinfo/sensor.py
@@ -157,7 +157,7 @@ class AfvalinfoSensor(Entity):
         return self._state
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         return {ATTR_YEAR_MONTH_DAY_DATE: self._year_month_day_date, ATTR_LAST_UPDATE: self._last_update, ATTR_HIDDEN: self._hidden, ATTR_DAYS_UNTIL_COLLECTION_DATE: self._days_until_collection_date, ATTR_IS_COLLECTION_DATE_TODAY: self._is_collection_date_today}
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)

--- a/custom_components/afvalinfo/sensortoday.py
+++ b/custom_components/afvalinfo/sensortoday.py
@@ -33,7 +33,7 @@ class AfvalInfoTodaySensor(Entity):
         return self._state
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         return {ATTR_LAST_UPDATE: self._last_update}
 
     @Throttle(timedelta(minutes=1))
@@ -45,7 +45,7 @@ class AfvalInfoTodaySensor(Entity):
         numberOfMatches = 0
         today = str(date.today().strftime("%Y-%m-%d"))
         for entity in self._entities:
-            if entity.device_state_attributes.get(ATTR_YEAR_MONTH_DAY_DATE) == today:
+            if entity.extra_state_attributes.get(ATTR_YEAR_MONTH_DAY_DATE) == today:
                 #reset tempState to empty string
                 if numberOfMatches == 0:
                     tempState = ""

--- a/custom_components/afvalinfo/sensortomorrow.py
+++ b/custom_components/afvalinfo/sensortomorrow.py
@@ -33,7 +33,7 @@ class AfvalInfoTomorrowSensor(Entity):
         return self._state
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         return {ATTR_LAST_UPDATE: self._last_update}
 
     @Throttle(timedelta(minutes=1))
@@ -45,7 +45,7 @@ class AfvalInfoTomorrowSensor(Entity):
         numberOfMatches = 0
         tomorrow = str((date.today() + timedelta(days=1)).strftime("%Y-%m-%d"))
         for entity in self._entities:
-            if entity.device_state_attributes.get(ATTR_YEAR_MONTH_DAY_DATE) == tomorrow:
+            if entity.extra_state_attributes.get(ATTR_YEAR_MONTH_DAY_DATE) == tomorrow:
                 #reset tempState to empty string
                 if numberOfMatches == 0:
                     tempState = ""


### PR DESCRIPTION
Fixes errors like:

```py
2021-12-05 14:14:28 WARNING (MainThread) [homeassistant.helpers.entity] Entity sensor.afvalinfo_gft (<class 'custom_components.afvalinfo.sensor.AfvalinfoSensor'>) implements device_state_attributes. Please report it to the custom component author.
2021-12-05 14:14:28 WARNING (MainThread) [homeassistant.helpers.entity] Entity sensor.afvalinfo_papier (<class 'custom_components.afvalinfo.sensor.AfvalinfoSensor'>) implements device_state_attributes. Please report it to the custom component author.
2021-12-05 14:14:28 WARNING (MainThread) [homeassistant.helpers.entity] Entity sensor.afvalinfo_pbd (<class 'custom_components.afvalinfo.sensor.AfvalinfoSensor'>) implements device_state_attributes. Please report it to the custom component author.
2021-12-05 14:14:28 WARNING (MainThread) [homeassistant.helpers.entity] Entity sensor.afvalinfo_restafval (<class 'custom_components.afvalinfo.sensor.AfvalinfoSensor'>) implements device_state_attributes. Please report it to the custom component author.
2021-12-05 14:14:28 WARNING (MainThread) [homeassistant.helpers.entity] Entity sensor.afvalinfo_today (<class 'custom_components.afvalinfo.sensortoday.AfvalInfoTodaySensor'>) implements device_state_attributes. Please report it to the custom component author.
2021-12-05 14:14:28 WARNING (MainThread) [homeassistant.helpers.entity] Entity sensor.afvalinfo_tomorrow (<class 'custom_components.afvalinfo.sensortomorrow.AfvalInfoTomorrowSensor'>) implements device_state_attributes. Please report it to the custom component author.
```

Fixes #231 