### PR TITLE
Config Flow reconfigure

### DIFF
--- a/custom_components/afvalinfo/config_flow.py
+++ b/custom_components/afvalinfo/config_flow.py
@@ -3,10 +3,15 @@
 Config flow component for Afvalinfo
 Author: Jasper Slits
 """
+from typing import Any
+from collections.abc import Mapping
 
 from homeassistant.helpers.selector import selector
 from homeassistant.helpers import config_validation as cv
 from homeassistant import config_entries
+from homeassistant.config_entries import (
+    ConfigFlowResult
+)
 from .const.const import (
     _LOGGER,
     DOMAIN,
@@ -29,6 +34,44 @@ import voluptuous as vol
 
 class AfvalWijzerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
+
+    async def async_step_reconfigure(
+                    self, user_input: Mapping[str, Any] | None = None
+                        ) -> ConfigFlowResult:
+        entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        assert entry
+        return await self._redo_configuration(entry.data)
+
+    async def _redo_configuration(
+                    self, entry_data: Mapping[str, Any]
+                        ) -> ConfigFlowResult:
+
+        options = list(SENSOR_TYPES.keys())
+        
+        afvalinfo_schema = vol.Schema({
+        vol.Required(CONF_ID, default=entry_data[CONF_ID]): str,
+        vol.Optional(CONF_POSTCODE, default=entry_data[CONF_POSTCODE] ): str,
+        vol.Optional(CONF_STREET_NUMBER, default=entry_data[CONF_STREET_NUMBER] ): cv.positive_int,
+        vol.Optional(CONF_STREET_NUMBER_SUFFIX, default=entry_data[CONF_STREET_NUMBER_SUFFIX]): str,
+        vol.Optional(CONF_LOCATION, default=entry_data[CONF_LOCATION]): str,
+        
+        vol.Optional(CONF_DISTRICT, default=entry_data[CONF_DISTRICT]): str,
+        vol.Optional(CONF_DATE_FORMAT, default=entry_data[CONF_DATE_FORMAT]): str,
+        vol.Optional(CONF_LOCALE, default=entry_data[CONF_LOCALE]): vol.In(["nl","en"]),
+        vol.Optional(CONF_NO_TRASH_TEXT, default=entry_data[CONF_NO_TRASH_TEXT] ): str,
+        vol.Optional(CONF_DIFTAR_CODE, default=entry_data[CONF_DIFTAR_CODE]): str,
+        vol.Optional(CONF_GET_WHOLE_YEAR, default=entry_data[CONF_GET_WHOLE_YEAR]): cv.boolean,
+        vol.Required(CONF_ENABLED_SENSORS,default=entry_data[CONF_ENABLED_SENSORS]): selector({
+                "select": {
+                    "options": options,
+                    "multiple": True,
+                    "translation_key": "sensorselect"
+                    }
+            })
+        })
+        return self.async_show_form(
+                         step_id="user", data_schema=afvalinfo_schema)
+
 
     async def async_step_user(self, info):
         if info is not None:

--- a/custom_components/afvalinfo/config_flow.py
+++ b/custom_components/afvalinfo/config_flow.py
@@ -40,6 +40,9 @@ class AfvalWijzerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         ) -> ConfigFlowResult:
         entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
         assert entry
+        if user_input:
+            return self.async_update_reload_and_abort(entry, data=user_input, reason="reconfigure_successful")
+
         return await self._redo_configuration(entry.data)
 
     async def _redo_configuration(
@@ -70,7 +73,7 @@ class AfvalWijzerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             })
         })
         return self.async_show_form(
-                         step_id="user", data_schema=afvalinfo_schema)
+                         step_id="reconfigure", data_schema=afvalinfo_schema)
 
 
     async def async_step_user(self, info):

--- a/custom_components/afvalinfo/strings.json
+++ b/custom_components/afvalinfo/strings.json
@@ -47,6 +47,10 @@
 		}
 	},
 	"config": {
+		"abort": {
+	  		"already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      			"reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"	  
+		},
 		"step": {
 			"user": {
 				"title": "Add new location",
@@ -67,10 +71,32 @@
 					"getwholeyear": "Get whole year",
 					"sensors": "Sensors to activate"
 				}
-			}
+			},
+			"reconfigure": {
+                                "title": "Update existing location",
+                                "description": "Config flow for afvalinfo",
+                                "data": {
+                                        "city": "City",
+                                        "location": "Location",
+                                        "postcode": "Zip code",
+                                        "streetnumber": "House number",
+                                        "streetnumbersuffix": "House number suffix",
+                                        "district": "District",
+                                        "dateformat": "Date format",
+                                        "locale": "Locale",
+                                        "id": "Identifier",
+                                        "timespanindays": "Timespan in days",
+                                        "notrashtext": "No trash text",
+                                        "diftarcode": "Diftar code",
+                                        "getwholeyear": "Get whole year",
+                                        "sensors": "Sensors to activate"
+                                }
+                        }
+
 		},
 		"abort": {
-			"already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
+			"already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
+			"reconfigure_successful": "Re-configuration was successful"
 		},
 		"error": {
 			"cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"

--- a/custom_components/afvalinfo/translations/en.json
+++ b/custom_components/afvalinfo/translations/en.json
@@ -64,10 +64,29 @@
 					"getwholeyear": "Get data for the whole year?",
 					"sensors": "Sensors"
 				}
-			}
-		},
+			},
+                        "reconfigure": {
+                                "title": "Afvalinfo",
+                                "description": "Update exsting location",
+                                "data": {
+                                        "location": "Municipality",
+                                        "postcode": "Zip code",
+                                        "streetnumber": "House number",
+                                        "streetnumbersuffix": "House number suffix",
+                                        "district": "District",
+                                        "dateformat": "Date format",
+                                        "locale": "Locale",
+                                        "id": "Identifier",
+                                        "notrashtext": "No trash text",
+                                        "diftarcode": "Diftar code",
+                                        "getwholeyear": "Get data for the whole year?",
+                                        "sensors": "Sensors"
+                                }
+                        }
+                },
 		"abort": {
-			"already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
+			"already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
+			"reconfigure_successful": "Re-configuration was successful"
 		},
 		"error": {
 			"cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"

--- a/custom_components/afvalinfo/translations/nl.json
+++ b/custom_components/afvalinfo/translations/nl.json
@@ -67,7 +67,8 @@
 			}
 		},
 		"abort": {
-			"already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
+			"already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
+			"reconfigure_successful": "Re-configuratie gelukt"
 		},
 		"error": {
 			"cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"


### PR DESCRIPTION
This PR adds reconfigure option to the Config Flow for AfvalInfo. 

It was annoying to delete and recreate it if you wanted to add a sensor to an existing entry. I ended up with two commits as the update of the changes initially didn't work. 

To configure the integration, click on the 3 dots next to Afvalinfo and click "Reconfigure". 

Tested with language = EN in HA 2024.04.2. 